### PR TITLE
Disable etp

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -3,7 +3,7 @@
 
 **Desription:** TacticalRMM Kubernetes manifests tested & working on Digital Ocean managed Kubernetes (DOKS).
 
-**Disclaimer:** _These manifests rely on an experimental developer images and as such are NOT SUPPORTED, at least until the required changes are merged into the main image. I have done my best to make them as secure as possible them however I am NOT responsible for anything that happens to you or your data as a result of using these files. Please do your due dilligence security-wise and open a Github issue if you wish to report a problem. USE AT YOUR OWN RISK. By using these files you agree that you are the sole entity responsible for any damages that may arise as a result._
+**Disclaimer:** _These manifests rely on experimental developer images and as such are NOT SUPPORTED, at least until the required changes are merged into the main image. I have done my best to make them as secure as possible however I am NOT responsible for anything that happens to you or your data as a result of using these files. Please do your due dilligence security-wise and open a Github issue if you wish to report a problem. USE AT YOUR OWN RISK. By using these files you agree that you are the sole entity responsible for any damages that may arise as a result._
 
 # Pre-requisites
 - A working Kubernetes cluster
@@ -14,6 +14,9 @@
 1. ```kubectl apply -f namespace.yaml```
 2. ```kubectl apply -f .```
 3. ```kubectl apply -f deployment/ -R```
+
+# Notes
+The load balancer has ```externalTrafficPolicy: Local``` disabled by default, as it caused a health check issue with the Digital Ocean Load Balancer these manifests were tested on. It may need to be enabled depending on your cloud provider, see https://docs.nats.io/running-a-nats-service/introduction/running/nats-kubernetes/nats-external-nlb for more info
 
 # Questions / Concerns
 Please open an issue in Github or you can also check in the [Tactical RMM Discord Channel](https://discord.gg/upGTkWp).

--- a/kubernetes/nlb.yaml
+++ b/kubernetes/nlb.yaml
@@ -8,7 +8,7 @@ metadata:
   name: tactical-nlb
 spec:
   type: LoadBalancer
-  externalTrafficPolicy: Local
+#  externalTrafficPolicy: Local
   ports:
     - name: "http"
       port: 80


### PR DESCRIPTION
Previously, the load balancer for TRMM was set to ```externalTrafficPolicy: Local```

It runs out this is not needed for the DO load balancer which these manifests are designed to run on by default.

It may be needed for other setups e.g. Amazon Kubernetes or local clusters - I have added a note to the documentation for that.