### PR TITLE
Fix missing namespace for network policy

### DIFF
--- a/kubernetes/network-policy.yaml
+++ b/kubernetes/network-policy.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: proxy
+  namespace: tacticalrmm
 spec:
   ingress:
   - {}


### PR DESCRIPTION
Forgot to put the namespace in the proxy network policy. This PR fixes it