### PR TITLE
Switch to non-root containers

### DIFF
--- a/kubernetes/deployment/tactical-backend.yaml
+++ b/kubernetes/deployment/tactical-backend.yaml
@@ -21,9 +21,12 @@ spec:
         network/proxy: "true"
         service: tactical-backend
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: trmm-backend
-          image: tacticalrmm/tactical:0.10.5-dev
+          image: tacticalrmm/tactical:0.11.4-dev
           args:
             - tactical-backend
           resources: {}
@@ -57,10 +60,10 @@ metadata:
 spec:
   ports:
     - name: "http"
-      port: 80
-      targetPort: 80
+      port: 8080
+      targetPort: 8080
     - name: "https"
-      port: 443
-      targetPort: 443
+      port: 4443
+      targetPort: 4443
   selector:
     service: tactical-backend

--- a/kubernetes/deployment/tactical-celery.yaml
+++ b/kubernetes/deployment/tactical-celery.yaml
@@ -25,7 +25,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: trmm-celery
-          image: tacticalrmm/tactical:0.10.5-dev
+          image: tacticalrmm/tactical:0.11.4-dev
           args:
             - tactical-celery
           resources: {}
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
         - name: trmm-celerybeat
-          image: tacticalrmm/tactical:latest
+          image: tacticalrmm/tactical:0.11.4-dev
           args:
             - tactical-celerybeat
           resources: {}

--- a/kubernetes/deployment/tactical-frontend.yaml
+++ b/kubernetes/deployment/tactical-frontend.yaml
@@ -17,9 +17,12 @@ spec:
       labels:
         service: tactical-frontend
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: trmm-frontend
-          image: tacticalrmm/tactical-frontend:latest
+          image: tacticalrmm/tactical-frontend:0.11.4-dev
           resources: {}
           env:
             - name: API_HOST
@@ -37,10 +40,7 @@ metadata:
 spec:
   ports:
     - name: "http"
-      port: 80
-      targetPort: 80
-    - name: "https"
-      port: 443
-      targetPort: 443
+      port: 8080
+      targetPort: 8080
   selector:
     service: tactical-frontend

--- a/kubernetes/deployment/tactical-init-pod.yaml
+++ b/kubernetes/deployment/tactical-init-pod.yaml
@@ -12,7 +12,7 @@ spec:
   containers:
     - args:
         - tactical-init
-      image: tacticalrmm/tactical:0.10.5-dev
+      image: tacticalrmm/tactical:0.11.4-dev
       name: trmm-init
       env:
         - name: API_HOST
@@ -22,7 +22,7 @@ spec:
         - name: MESH_HOST
           value: mesh.rmm.mydomain.com
         - name: MESH_WS_URL
-          value: ws://tactical-meshcentral:443
+          value: ws://tactical-meshcentral:4443
         - name: MESH_USER
           value: meshuser
         - name: POSTGRES_HOST

--- a/kubernetes/deployment/tactical-meshcentral.yaml
+++ b/kubernetes/deployment/tactical-meshcentral.yaml
@@ -20,9 +20,12 @@ spec:
         network/proxy: "true"
         service: tactical-meshcentral
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: trmm-meshcentral
-          image: tacticalrmm/tactical-meshcentral:0.10.5-dev
+          image: tacticalrmm/tactical-meshcentral:0.11.4-dev
           resources: {}
           env:
             - name: MESH_HOST
@@ -45,6 +48,8 @@ spec:
                   key: mongodb-password
             - name: NGINX_HOST_IP # Point to NGINX service
               value: tactical-nlb
+            - name: NGINX_HOST_PORT # Should match the EXTERNAL port of the NGINX service
+              value: "443"
             - name: WS_MASK_OVERRIDE # Enable for Traefik compatibility
               value: "0"
             - name: SMTP_HOST
@@ -87,10 +92,10 @@ metadata:
 spec:
   ports:
     - name: "http"
-      port: 80
-      targetPort: 80
+      port: 8080
+      targetPort: 8080
     - name: "https"
-      port: 443
-      targetPort: 443
+      port: 4443
+      targetPort: 4443
   selector:
     service: tactical-meshcentral

--- a/kubernetes/deployment/tactical-mongodb.yaml
+++ b/kubernetes/deployment/tactical-mongodb.yaml
@@ -20,8 +20,8 @@ spec:
         service: tactical-mongodb
     spec:
       securityContext:
-        runAsUser: 2000
-        fsGroup: 2000
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: trmm-mongodb
           image: mongo:4.4

--- a/kubernetes/deployment/tactical-web.yaml
+++ b/kubernetes/deployment/tactical-web.yaml
@@ -19,9 +19,12 @@ spec:
         network/proxy: "true"
         service: tactical-nlb
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: nginx
-          image: tacticalrmm/tactical-nginx:0.10.5-dev
+          image: tacticalrmm/tactical-nginx:0.11.4-dev
           resources: {}
           env:
             - name: API_HOST
@@ -45,19 +48,21 @@ spec:
             - name: CERT_PRIV_PATH
               value: /etc/ssl/certs/custom/tls.key
           ports:
-            - containerPort: 80
-            - containerPort: 443
+            - containerPort: 8080
+            - containerPort: 4443
           volumeMounts:
             - mountPath: /opt/tactical
               name: tactical-data
             - mountPath: /etc/ssl/certs/custom
               name: tactical-certs
         - name: trmm-nats
-          image: tacticalrmm/tactical-nats:latest
+          image: tacticalrmm/tactical-nats:0.11.4-dev
           resources: {}
           env:
             - name: API_HOST
               value: api.rmm.mydomain.com
+            - name: NATS_CONFIG_CHECK_INTERVAL
+              value: "10"
           ports:
             - containerPort: 4222
           volumeMounts:

--- a/kubernetes/deployment/tactical-websockets.yaml
+++ b/kubernetes/deployment/tactical-websockets.yaml
@@ -26,7 +26,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: trmm-websockets
-          image: tacticalrmm/tactical:latest
+          image: tacticalrmm/tactical:0.11.4-dev
           args:
             - tactical-websockets
           resources: {}


### PR DESCRIPTION
Reference PR: https://github.com/wh1te909/tacticalrmm/pull/939

Reference Issue: https://github.com/wh1te909/tacticalrmm/issues/913

This PR updates the K8s manifests to run all containers as non-root (to resolve security issues of running containers as root).