### PR TITLE
Update manifests for 0.14.1

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -3,7 +3,7 @@
 
 **Desription:** TacticalRMM Kubernetes manifests tested & working on Digital Ocean managed Kubernetes (DOKS).
 
-**Disclaimer:** _These manifests rely on experimental developer images and as such are NOT SUPPORTED, at least until the required changes are merged into the main image. I have done my best to make them as secure as possible however I am NOT responsible for anything that happens to you or your data as a result of using these files. Please do your due dilligence security-wise and open a Github issue if you wish to report a problem. USE AT YOUR OWN RISK. By using these files you agree that you are the sole entity responsible for any damages that may arise as a result._
+**Disclaimer:** _These manifests are experimental and as such are NOT SUPPORTED. I have done my best to make them as secure as possible however I am NOT responsible for anything that happens to you or your data as a result of using these files. Please do your due dilligence security-wise and open a Github issue if you wish to report a problem. USE AT YOUR OWN RISK. By using these files you agree that you are the sole entity responsible for any damages that may arise as a result._
 
 # Pre-requisites
 - A working Kubernetes cluster

--- a/kubernetes/deployment/tactical-backend.yaml
+++ b/kubernetes/deployment/tactical-backend.yaml
@@ -26,7 +26,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: trmm-backend
-          image: tacticalrmm/tactical:0.11.4-dev
+          image: tacticalrmm/tactical:0.14.1
           args:
             - tactical-backend
           resources: {}

--- a/kubernetes/deployment/tactical-celery.yaml
+++ b/kubernetes/deployment/tactical-celery.yaml
@@ -25,7 +25,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: trmm-celery
-          image: tacticalrmm/tactical:0.11.4-dev
+          image: tacticalrmm/tactical:0.14.1
           args:
             - tactical-celery
           resources: {}
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
         - name: trmm-celerybeat
-          image: tacticalrmm/tactical:0.11.4-dev
+          image: tacticalrmm/tactical:0.14.1
           args:
             - tactical-celerybeat
           resources: {}

--- a/kubernetes/deployment/tactical-frontend.yaml
+++ b/kubernetes/deployment/tactical-frontend.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: trmm-frontend
-          image: tacticalrmm/tactical-frontend:0.11.4-dev
+          image: tacticalrmm/tactical-frontend:0.14.1
           resources: {}
           env:
             - name: API_HOST

--- a/kubernetes/deployment/tactical-init-pod.yaml
+++ b/kubernetes/deployment/tactical-init-pod.yaml
@@ -12,7 +12,7 @@ spec:
   containers:
     - args:
         - tactical-init
-      image: tacticalrmm/tactical:0.11.4-dev
+      image: tacticalrmm/tactical:0.14.1
       name: trmm-init
       env:
         - name: API_HOST

--- a/kubernetes/deployment/tactical-meshcentral.yaml
+++ b/kubernetes/deployment/tactical-meshcentral.yaml
@@ -25,7 +25,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: trmm-meshcentral
-          image: tacticalrmm/tactical-meshcentral:0.11.4-dev
+          image: tacticalrmm/tactical-meshcentral:0.14.1
           resources: {}
           env:
             - name: MESH_HOST

--- a/kubernetes/deployment/tactical-web.yaml
+++ b/kubernetes/deployment/tactical-web.yaml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: nginx
-          image: tacticalrmm/tactical-nginx:0.11.4-dev
+          image: tacticalrmm/tactical-nginx:0.14.1
           resources: {}
           env:
             - name: API_HOST
@@ -43,6 +43,8 @@ spec:
               value: tactical-meshcentral.tacticalrmm.svc.cluster.local
             - name: WEBSOCKETS_SERVICE
               value: tactical-websockets.tacticalrmm.svc.cluster.local
+            - name: NATS_SERVICE
+              value: tactical-nats.tacticalrmm.svc.cluster.local
             - name: CERT_PUB_PATH
               value: /etc/ssl/certs/custom/tls.crt
             - name: CERT_PRIV_PATH
@@ -56,7 +58,7 @@ spec:
             - mountPath: /etc/ssl/certs/custom
               name: tactical-certs
         - name: trmm-nats
-          image: tacticalrmm/tactical-nats:0.11.4-dev
+          image: tacticalrmm/tactical-nats:0.14.1
           resources: {}
           env:
             - name: API_HOST
@@ -65,6 +67,7 @@ spec:
               value: "10"
           ports:
             - containerPort: 4222
+            - containerPort: 9235
           volumeMounts:
             - mountPath: /opt/tactical
               name: tactical-data
@@ -79,3 +82,19 @@ spec:
           secret:
             secretName: rmm-mydomain-com-tls
 status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: tacticalrmm
+  labels:
+    app: tacticalrmm
+    service: tactical-nats
+  name: tactical-nats
+spec:
+  type: ClusterIP
+  ports:
+    - name: "nats-ws"
+      port: 9235
+  selector:
+    service: tactical-nlb

--- a/kubernetes/deployment/tactical-websockets.yaml
+++ b/kubernetes/deployment/tactical-websockets.yaml
@@ -26,7 +26,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: trmm-websockets
-          image: tacticalrmm/tactical:0.11.4-dev
+          image: tacticalrmm/tactical:0.14.1
           args:
             - tactical-websockets
           resources: {}


### PR DESCRIPTION
The purpose of this change is to incorporate the changes made to NATS in version 0.14.0+

- Expose NATS pod on port 9235
- Create the necessary service for routing traffic to the NATS pod
- Set the environment variable on the NGINX container to use the [service FQDN](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1)

See https://github.com/amidaware/tacticalrmm/releases/tag/v0.14.0 for details